### PR TITLE
feat: add insertAfter shortcuts

### DIFF
--- a/src/common/funcs.ts
+++ b/src/common/funcs.ts
@@ -138,6 +138,7 @@ export const defaultSettings = {
   indent: 'l',
   insert: ['i', 'a'],
   insertBefore: 'shift+i',
+  insertAfter: 'shift+a',
   nextNewBlock: 'o',
   nextSibling: 'shift+j',
   outdent: 'h',

--- a/src/keybindings/insertAfter.ts
+++ b/src/keybindings/insertAfter.ts
@@ -1,0 +1,29 @@
+import { ILSPluginUser } from '@logseq/libs/dist/LSPlugin';
+import { debug, getCurrentBlockUUID, getSettings } from '../common/funcs';
+
+export default (logseq: ILSPluginUser) => {
+  const settings = getSettings();
+
+  const bindings = Array.isArray(settings.insertAfter) ? settings.insertAfter : [settings.insertAfter];
+
+  bindings.forEach((binding, index) => {
+    logseq.App.registerCommandPalette({
+      key: 'vim-shortcut-insert-after-' + index,
+      label: 'Enter insert mode at last pos',
+      keybinding: {
+        mode: 'non-editing',
+        binding,
+      }
+    }, async () => {
+      debug('Insert after');
+
+      let blockUUID = await getCurrentBlockUUID();
+      if (blockUUID) {
+        const block = await logseq.Editor.getBlock(blockUUID)
+        await logseq.Editor.editBlock(blockUUID, {
+          pos: block.meta.endPos
+        });
+      }
+    });
+  });
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import highlightFocusOut from './keybindings/highlightFocusOut';
 import indent from './keybindings/indent';
 import insert from './keybindings/insert';
 import insertBefore from './keybindings/insertBefore';
+import insertAfter from './keybindings/insertAfter';
 import joinNextLine from './keybindings/joinNextLine';
 import jumpInto from './keybindings/jumpInto';
 import mark from './keybindings/mark';
@@ -56,6 +57,7 @@ async function main() {
 
   insert(logseq);
   insertBefore(logseq);
+  insertAfter(logseq);
 
   top(logseq);
   bottom(logseq);


### PR DESCRIPTION
Thanks for this work!

I noticed that this repo only supports `insert before`. I think `insert after` is also a frequently-used shortcut in vim, so I create this PR.