### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This plugin provide some shortcuts which give Logseq a VIM-like feeling.
 - `ctrl+a`: Increase the first found number in block. Supports multiple selections and combo.
 - `ctrl+x`: Decrease the first found number in block. Supports multiple selections and combo.
 - `x`: Cut a leading character. Supports multiple selections.
-- `x`: Cut a leading word. Supports multiple selections.
+- `X`: Cut a leading word. Supports multiple selections.
 - `/`: Trigger search in page bar on the below. Supports smartcase.
 - `n`: Search next search match.
 - `N`: Search previous search match.


### PR DESCRIPTION
In the README it describes `x` doing two different actions. `X` is the shortcut to delete the first word of the blocks in the selection, not `x`.